### PR TITLE
Enhance vacation support in timesheet operations and update version to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Install via Chrome Web Store: [Timesheet Helper](https://chromewebstore.google.c
 - **📋 Copy from Hilan**: Read actual in/out times
 - **📝 Paste to Malam**: Fill payroll timesheet automatically
 - **📊 Local Stats**: Optional, on-device analytics (can be disabled in the popup)
+- **🏖️ Vacation Support**: Copies vacation days to Malam
 - **🌐 i18n**: English and Hebrew support
 
 ### Install (Developer mode)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "icons": {
@@ -35,6 +35,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; connect-src 'self'; img-src 'self' data:; style-src 'self'; font-src 'self' data:; require-trusted-types-for 'script'; trusted-types default"
+    "extension_pages": "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; connect-src 'self'; img-src 'self' data:; style-src 'self'; font-src 'self' data: https://r2cdn.perplexity.ai; require-trusted-types-for 'script'; trusted-types default"
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -35,6 +35,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; connect-src 'self'; img-src 'self' data:; style-src 'self'; font-src 'self' data: https://r2cdn.perplexity.ai; require-trusted-types-for 'script'; trusted-types default"
+    "extension_pages": "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; connect-src 'self'; img-src 'self' data:; style-src 'self'; font-src 'self' data:; require-trusted-types-for 'script'; trusted-types default"
   }
 }

--- a/src/shared/common.ts
+++ b/src/shared/common.ts
@@ -158,16 +158,19 @@ const SITES: Record<string, SiteConfig> = {
 };
 
 const SELECTORS: Selectors = {
-  HILAN_TIME_BOXES: 'td[class*="cDIES"], td[class*="cHD"]',
+  HILAN_TIME_BOXES:
+    'td[class*="cDIES"], td[class*="cHD"], td[class*="cMAD"], td[class*="calendarAbcenseDay"]',
   HILAN_DATE_CELL: 'td[id*="cellOf_ReportDate"]',
   HILAN_ENTRY_TIME: 'td[id*="cellOf_ManualEntry_EmployeeReports"]',
   HILAN_EXIT_TIME: 'td[id*="cellOf_ManualExit_EmployeeReports"]',
+  HILAN_SYMBOL: 'select[id*="Symbol"]',
   HILAN_TIME_CONTENT: '.cDM',
   HILAN_CLICKED_CLASS: 'CSD',
   MALAM_ROWS: '#pt1\\:dataTable tr[role="row"]',
   MALAM_DATE_INPUT: 'input[id*="clockInDate"][id*="content"]',
   MALAM_CLOCK_IN: 'input[id*="clockInTime"][id*="content"]',
   MALAM_CLOCK_OUT: 'input[id*="clockOutTime"][id*="content"]',
+  MALAM_WORK_TYPE: 'select[id*="workTypeSelect"]',
 };
 
 const ERROR_CODES: Record<string, ErrorCode> = {

--- a/src/shared/common.ts
+++ b/src/shared/common.ts
@@ -159,7 +159,7 @@ const SITES: Record<string, SiteConfig> = {
 
 const SELECTORS: Selectors = {
   HILAN_TIME_BOXES:
-    'td[class*="cDIES"], td[class*="cHD"], td[class*="cMAD"], td[class*="calendarAbcenseDay"]',
+    'td[class*="cDIES"], td[class*="cHD"], td[class*="cMAD"], td[class*="calendarAbcenseDay"], td[class*="calendarAbsenceDay"]',
   HILAN_DATE_CELL: 'td[id*="cellOf_ReportDate"]',
   HILAN_ENTRY_TIME: 'td[id*="cellOf_ManualEntry_EmployeeReports"]',
   HILAN_EXIT_TIME: 'td[id*="cellOf_ManualExit_EmployeeReports"]',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,8 @@
-// Core domain types
 export interface TimesheetEntry {
   entryTime: string;
   exitTime: string;
   originalHilanDate: string;
+  isVacation?: boolean;
 }
 
 export interface TimesheetData {
@@ -95,12 +95,14 @@ export interface Selectors {
   HILAN_EXIT_TIME: string;
   HILAN_TIME_CONTENT: string;
   HILAN_CLICKED_CLASS: string;
+  HILAN_SYMBOL: string;
 
   // Malam selectors
   MALAM_ROWS: string;
   MALAM_DATE_INPUT: string;
   MALAM_CLOCK_IN: string;
   MALAM_CLOCK_OUT: string;
+  MALAM_WORK_TYPE: string;
 }
 
 // Error codes (strongly typed)


### PR DESCRIPTION
This pull request adds support for handling vacation days in the timesheet automation process, ensuring that vacation days from Hilan are correctly copied and set in Malam. It also includes minor updates to selectors, types, and the manifest.

**Vacation day support:**

* Added logic to detect vacation days in Hilan by checking cell content and symbol, and to mark these days in the generated `TimesheetEntry` (`isVacation` property).
* Updated the process for filling Malam timesheets: if a day is marked as vacation, sets the work type selector to "Vacation" instead of filling in entry/exit times.
* Updated the README to mention vacation support as a feature.

**Selectors and types:**

* Added new selectors for Hilan vacation symbol and Malam work type, and updated the time box selector to include additional vacation-related classes.

**Miscellaneous:**

* Bumped the extension version to 1.0.2 in `manifest.json`.
* Updated the content security policy to allow fonts from an additional domain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements vacation-day flow end-to-end between Hilan and Malam.
> 
> - Detects vacations in Hilan via cell text/title and `select` symbol (`HILAN_SYMBOL`), and allows entries without times when `isVacation`
> - Persists `isVacation` in `TimesheetEntry`; during paste, selects `MALAM_WORK_TYPE` = Vacation (`1_0`) instead of filling times
> - Expands selectors: broader `HILAN_TIME_BOXES` coverage; adds `HILAN_SYMBOL` and `MALAM_WORK_TYPE`
> - Docs: README adds Vacation Support; `manifest.json` version updated to `1.0.2`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eba66f8a760733020943237a7284960c20858ca4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->