### PR TITLE
Update package and manifest versions to 1.0.3, and enhance date handling logic in timesheet operations for improved accuracy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "Timesheet-Helper",
-  "version": "1.0.0",
+  "name": "timesheet-helper",
+  "version": "1.0.3",
   "description": "Timesheet automation extension for Hilan and Malam Timesheet systems",
   "type": "module",
   "scripts": {

--- a/src/content/timesheet-operations.ts
+++ b/src/content/timesheet-operations.ts
@@ -138,9 +138,23 @@ export class TimesheetOperations {
         continue;
       }
 
-      const malamDate = hilanDate.includes('/')
-        ? `${hilanDate}/${new Date().getFullYear()}`
-        : null;
+      let malamDate: string | null = null;
+      if (hilanDate.includes('/')) {
+        const parts = hilanDate.split('/');
+        if (parts.length === 3) {
+          malamDate = hilanDate;
+        } else if (parts.length === 2) {
+          const monthStr = parts[1];
+          if (monthStr) {
+            const month = parseInt(monthStr, 10);
+            const now = new Date();
+            const currentMonth = now.getMonth() + 1;
+            const currentYear = now.getFullYear();
+            const year = month > currentMonth ? currentYear - 1 : currentYear;
+            malamDate = `${hilanDate}/${year}`;
+          }
+        }
+      }
       if (!malamDate) {
         continue;
       }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
This pull request updates the `timesheet-helper` extension with a version bump and improves the date parsing logic for Malam timesheet entries. The most important changes are:

Version and naming updates:
* Changed the package name in `package.json` from `Timesheet-Helper` to `timesheet-helper` and updated the version from `1.0.0` to `1.0.3` for consistency and to reflect the latest release.
* Updated the extension version in `src/manifest.json` from `1.0.2` to `1.0.3` to match the package version.

Date parsing improvements:
* Enhanced the logic in `TimesheetOperations` (`src/content/timesheet-operations.ts`) to more robustly handle date strings when converting Hilan dates to Malam format. The new logic infers the correct year for two-part dates by comparing the month to the current month, improving accuracy for year transitions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Hilan→Malam date conversion and aligns extension/package versions.
> 
> - **Date parsing:** In `src/content/timesheet-operations.ts`, replaces simple year-append logic with robust `malamDate` construction: keeps 3-part dates as-is and, for 2-part dates, infers the year based on current month vs. parsed month; skips when a valid date can't be derived.
> - **Versioning/metadata:** Renames package to `timesheet-helper` and bumps versions to `1.0.3` in `package.json` and `src/manifest.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c71f0ac3751cd45b7d845cd8e6506366450f8173. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->