### PR TITLE
Implement settings page with theme and language options.

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -87,6 +87,10 @@
     "message": "Clear All Data",
     "description": "Clear data button text"
   },
+  "languageSystem": {
+    "message": "System",
+    "description": "System language option"
+  },
   "languageEnglish": {
     "message": "English",
     "description": "English language option"
@@ -210,6 +214,38 @@
   "statistics": {
     "message": "Statistics",
     "description": "Statistics section title and toggle label"
+  },
+  "settings": {
+    "message": "Settings",
+    "description": "Settings page title"
+  },
+  "appearance": {
+    "message": "Appearance",
+    "description": "Appearance settings section title"
+  },
+  "theme": {
+    "message": "Theme",
+    "description": "Theme setting label"
+  },
+  "themeSystem": {
+    "message": "System",
+    "description": "System theme option"
+  },
+  "themeLight": {
+    "message": "Light",
+    "description": "Light theme option"
+  },
+  "themeDark": {
+    "message": "Dark",
+    "description": "Dark theme option"
+  },
+  "enableStatistics": {
+    "message": "Enable",
+    "description": "Enable statistics toggle label"
+  },
+  "dataManagement": {
+    "message": "Data",
+    "description": "Data management settings section title"
   },
   "modalTitle": {
     "message": "Clear All Extension Data?",

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -87,6 +87,10 @@
     "message": "נקה את כל הנתונים",
     "description": "Clear data button text"
   },
+  "languageSystem": {
+    "message": "מערכת",
+    "description": "System language option"
+  },
   "languageEnglish": {
     "message": "English",
     "description": "English language option"
@@ -210,6 +214,38 @@
   "statistics": {
     "message": "סטטיסטיקות",
     "description": "Statistics section title and toggle label"
+  },
+  "settings": {
+    "message": "הגדרות",
+    "description": "Settings page title"
+  },
+  "appearance": {
+    "message": "מראה",
+    "description": "Appearance settings section title"
+  },
+  "theme": {
+    "message": "ערכת נושא",
+    "description": "Theme setting label"
+  },
+  "themeSystem": {
+    "message": "מערכת",
+    "description": "System theme option"
+  },
+  "themeLight": {
+    "message": "בהיר",
+    "description": "Light theme option"
+  },
+  "themeDark": {
+    "message": "כהה",
+    "description": "Dark theme option"
+  },
+  "enableStatistics": {
+    "message": "הפעל",
+    "description": "Enable statistics toggle label"
+  },
+  "dataManagement": {
+    "message": "נתונים",
+    "description": "Data management settings section title"
   },
   "modalTitle": {
     "message": "למחוק את כל נתוני התוסף?",

--- a/src/popup.html
+++ b/src/popup.html
@@ -12,6 +12,9 @@
         <div class="logo"></div>
         <h1 data-i18n="pageTitle">Timesheet Helper</h1>
         <span class="context-badge unknown" data-i18n="unknownWebsite">Unknown Website</span>
+        <button id="settingsButton" class="icon-button" aria-label="Settings">
+          <span>⚙️</span>
+        </button>
       </div>
       <div class="toggle-section">
         <label class="toggle-container">
@@ -19,21 +22,6 @@
           <span class="toggle-slider"></span>
           <span class="toggle-label">Extension Enabled</span>
         </label>
-      </div>
-      <div class="language-section">
-        <button id="languageToggle" class="language-button">
-          <span class="language-icon">🌐</span>
-          <span class="language-text" data-i18n="languageToggle">Language</span>
-          <span class="language-arrow">▼</span>
-        </button>
-        <div id="languageDropdown" class="language-dropdown hidden">
-          <div class="language-option" data-lang="en">
-            <span data-i18n="languageEnglish">English</span>
-          </div>
-          <div class="language-option" data-lang="he">
-            <span data-i18n="languageHebrew">עברית</span>
-          </div>
-        </div>
       </div>
       <div class="collapsible-content">
         <p class="guidance-text" data-i18n="guidanceTextDefault">
@@ -48,48 +36,72 @@
           <span class="button-text" data-i18n="syncHours">Sync Hours</span>
         </button>
         <div id="status"></div>
-        <div class="toggle-section statistics-toggle-section">
-          <label class="toggle-container">
-            <input type="checkbox" id="statisticsToggle" />
-            <span class="toggle-slider"></span>
-            <span class="toggle-label" data-i18n="statistics">Statistics</span>
-          </label>
-        </div>
-        <div class="analytics-section">
-          <div class="analytics-header">
-            <span class="analytics-icon">📊</span>
-            <span class="analytics-title" data-i18n="statistics">Statistics</span>
-          </div>
-          <div class="analytics-stats">
-            <div class="stat-item">
-              <span class="stat-label" data-i18n="statLastCopied">Last copied:</span>
-              <span class="stat-value" data-i18n="statNever">Never</span>
-            </div>
-            <div class="stat-item">
-              <span class="stat-label" data-i18n="statLastPasted">Last pasted:</span>
-              <span class="stat-value" data-i18n="statNever">Never</span>
-            </div>
-            <div class="stat-item">
-              <span class="stat-label" data-i18n="statLastAutoClick">Last auto-click:</span>
-              <span class="stat-value" data-i18n="statNever">Never</span>
-            </div>
-            <div class="stat-item">
-              <span class="stat-label" data-i18n="statTotalOperations">Total operations:</span>
-              <span class="stat-value">0</span>
-            </div>
-            <div class="stat-item">
-              <span class="stat-label" data-i18n="statSuccessRate">Success rate:</span>
-              <span class="stat-value">0%</span>
-            </div>
-          </div>
-          <button id="clearDataButton" class="btn-base clear-data-button">
-            <span class="button-icon">🗑️</span>
-            <span class="clear-text" data-i18n="clearAllData">Clear All Data</span>
-          </button>
-        </div>
       </div>
       <div class="footer">
         <span class="footer-text" data-i18n="footerMadeBy">Made by Segev Levinshtein</span>
+      </div>
+    </div>
+    <div class="settings-container hidden">
+      <div class="settings-header">
+        <button id="backButton" class="icon-button" aria-label="Back">←</button>
+        <h2 data-i18n="settings">Settings</h2>
+      </div>
+
+      <div class="settings-section">
+        <h3 class="settings-section-title" data-i18n="appearance">Appearance</h3>
+        <div class="setting-item">
+          <span class="setting-label" data-i18n="theme">Theme</span>
+          <select id="themeSelect" class="setting-select">
+            <option value="system" data-i18n="themeSystem">System</option>
+            <option value="light" data-i18n="themeLight">Light</option>
+            <option value="dark" data-i18n="themeDark">Dark</option>
+          </select>
+        </div>
+        <div class="setting-item">
+          <span class="setting-label" data-i18n="languageToggle">Language</span>
+          <select id="languageSelect" class="setting-select">
+            <option value="system" data-i18n="languageSystem">System</option>
+            <option value="en">English</option>
+            <option value="he">עברית</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="settings-section">
+        <h3 class="settings-section-title" data-i18n="statistics">Statistics</h3>
+        <label class="toggle-container">
+          <input type="checkbox" id="statisticsToggle" />
+          <span class="toggle-slider"></span>
+          <span class="toggle-label" data-i18n="enableStatistics">Enable</span>
+        </label>
+        <div id="statisticsContent" class="statistics-content">
+          <div class="stat-item">
+            <span class="stat-label" data-i18n="statLastCopied">Last copied:</span
+            ><span class="stat-value" data-i18n="statNever">Never</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label" data-i18n="statLastPasted">Last pasted:</span
+            ><span class="stat-value" data-i18n="statNever">Never</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label" data-i18n="statLastAutoClick">Last auto-click:</span
+            ><span class="stat-value" data-i18n="statNever">Never</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label" data-i18n="statTotalOperations">Total:</span><span class="stat-value">0</span>
+          </div>
+          <div class="stat-item">
+            <span class="stat-label" data-i18n="statSuccessRate">Success:</span><span class="stat-value">0%</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="settings-section">
+        <h3 class="settings-section-title" data-i18n="dataManagement">Data</h3>
+        <button id="clearDataButtonSettings" class="btn-base clear-data-button">
+          <span class="button-icon">🗑️</span>
+          <span data-i18n="clearAllData">Clear All Data</span>
+        </button>
       </div>
     </div>
     <div id="confirmModal" class="modal-overlay hidden">

--- a/src/styles/components/foundation.css
+++ b/src/styles/components/foundation.css
@@ -97,6 +97,22 @@
   }
 }
 
+/* Theme Attribute Overrides */
+[data-theme='dark'] {
+  --surface-primary: var(--color-gray-900);
+  --surface-secondary: var(--color-gray-800);
+  --text-primary: var(--color-white);
+  --text-secondary: var(--color-gray-400);
+  --border-default: var(--color-gray-700);
+}
+[data-theme='light'] {
+  --surface-primary: var(--color-white);
+  --surface-secondary: var(--color-gray-50);
+  --text-primary: var(--color-gray-900);
+  --text-secondary: var(--color-gray-600);
+  --border-default: var(--color-gray-300);
+}
+
 /* ===== BASE STYLES ===== */
 
 /* Box Sizing */

--- a/src/styles/components/layout.css
+++ b/src/styles/components/layout.css
@@ -24,7 +24,7 @@
 
 /* Body width */
 body.popup-expanded {
-  width: 270px;
+  width: 300px;
 }
 
 body.popup-collapsed {
@@ -261,6 +261,93 @@ body.popup-collapsed {
 /* ===== SPECIAL UTILITIES ===== */
 #autoClickButton {
   margin-bottom: var(--space-sm);
+}
+
+/* ===== ICON BUTTON ===== */
+.icon-button {
+  background: transparent;
+  border: none;
+  padding: var(--space-sm);
+  cursor: pointer;
+  font-size: var(--font-size-md);
+  color: var(--text-secondary);
+  opacity: 0.85;
+  transition: opacity var(--transition-fast);
+  line-height: 1;
+}
+.icon-button:hover {
+  opacity: 1;
+  color: var(--text-primary);
+}
+
+/* ===== SETTINGS PAGE ===== */
+.settings-container {
+  padding: var(--space-lg);
+  animation: fadeIn var(--transition-smooth);
+}
+.settings-container.hidden {
+  display: none;
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+  padding-bottom: var(--space-md);
+  border-bottom: 1px solid var(--border-default);
+}
+.settings-header h2 {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  margin: 0;
+  flex: 1;
+}
+
+.settings-section {
+  margin-bottom: var(--space-lg);
+}
+
+.settings-section-title {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 0 0 var(--space-md) 0;
+}
+
+.setting-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-sm) 0;
+}
+
+.setting-label {
+  font-size: var(--font-size-base);
+  color: var(--text-primary);
+}
+
+.setting-select {
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.statistics-content {
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  background: var(--surface-secondary);
+  border-radius: var(--radius-md);
+}
+.statistics-content.hidden {
+  display: none;
 }
 
 /* ===== MODAL SYSTEM ===== */


### PR DESCRIPTION
This pull request introduces a major redesign of the popup UI, centralizing language, theme, and statistics settings into a new dedicated settings page. It also adds support for a "System" option for both language and theme, improves localization, and updates the statistics display. The changes modernize the user experience and streamline the interface.

**UI/UX Redesign:**

* Replaces the old language dropdown with a new settings page accessible via a settings button, where users can select language, theme, and manage data. The main popup now focuses on core functionality, and settings are separated into their own view.

**Language and Theme Systemization:**

* Adds a "System" option for both language and theme, automatically adapting to the user's browser or OS preferences. Updates the logic in `i18n.ts` and `popup.ts` to support these options throughout the extension.

**Localization Improvements:**

* Updates English and Hebrew locale files to include new keys for settings, appearance, theme, and system options, ensuring all new UI elements are translatable.

**Statistics and Data Management:**

* Moves statistics controls and analytics to the settings page, updates the statistics section layout, and ensures statistics visibility and state are handled correctly. Adds a "Clear All Data" button to the settings page, which now also resets language and theme to system defaults.

**Styling and Layout Enhancements:**

* Adds CSS for theme attribute overrides, supporting light and dark themes via a `data-theme` attribute. Adjusts popup width for improved layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes the popup by separating configuration into a dedicated settings page and adding system-aware theme/language support.
> 
> - New settings UI in `popup.html`/`popup.ts` with navigation (settings/back), controls for `theme` (system/light/dark) and `language` (system/en/he), statistics toggle/view, and a data management section
> - i18n updated in `i18n.ts` to support a `'system'` language mode (auto-detect from browser), persist selection, and refresh UI direction/strings on change; locales (`_locales/en|he/messages.json`) extended with settings/theme keys
> - Styling: theme applied via `data-theme` attribute with light/dark overrides; new settings and icon-button styles; popup expanded width adjusted to 300px
> - Behavior tweaks: statistics moved to settings and visibility handled via `#statisticsContent`; clear data now resets language/theme to system defaults and refreshes UI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 471fdb79280764e91b973e28ad29c8cd01b5606e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->