### PR TITLE
Update README and privacy policy last updated date

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Chrome injects the content script only on these paths, at `document_end`. Everyw
 
 Everything runs on your machine. No servers, no analytics, no network requests. Your data stays in `chrome.storage.local`.
 
-- The extension asks for `storage` and host access to the Hilan and Malam paths above. Nothing else.
+- The extension asks for `storage` and host access on `*.hilan.co.il` and `payroll.malam.com`. Chrome grants host access by origin. The content script still runs only on the supported paths above.
 - The content security policy allows scripts and connections only from `'self'`, blocks plugins with `object-src 'none'`, and requires Trusted Types for script sinks.
 - ESLint blocks production code from using HTML-injection sinks such as `innerHTML`, `outerHTML`, `insertAdjacentHTML`, `document.write`, and `createContextualFragment`, along with `eval` and `new Function`.
 

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -134,9 +134,11 @@
       <ul>
         <li><code>storage</code> saves the items listed above on your device.</li>
         <li>
-          Host access limited to Hilan attendance pages (<code>https://*.hilan.co.il/Hilannetv2/Attendance/*</code> and
-          <code>https://*.hilan.co.il/Hilannetv2/attendance/*</code>) and Malam payroll pages
-          (<code>https://payroll.malam.com/Salprd5Root/faces/*</code>). The content script runs only on those paths.
+          Host access covers <code>*.hilan.co.il</code> and <code>payroll.malam.com</code>. Chrome grants host access
+          by origin, even though the manifest syntax includes paths. The content script runs only on the Hilan
+          attendance paths (<code>https://*.hilan.co.il/Hilannetv2/Attendance/*</code> and
+          <code>https://*.hilan.co.il/Hilannetv2/attendance/*</code>) and the Malam payroll path
+          (<code>https://payroll.malam.com/Salprd5Root/faces/*</code>).
         </li>
       </ul>
 

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -91,7 +91,7 @@
   <body>
     <main>
       <h1>Privacy policy</h1>
-      <p class="updated">Timesheet Helper &middot; Last updated 2026-06-03</p>
+      <p class="updated">Timesheet Helper &middot; Last updated 2026-06-05</p>
 
       <p>
         Timesheet Helper runs locally in Chrome. It copies your working hours from a Hilan timesheet into Malam payroll.


### PR DESCRIPTION
This pull request updates the documentation to clarify how host permissions are granted and used in the Chrome extension. The changes make it clear that while the manifest may specify paths, Chrome grants host access by origin, and the content script is still limited to specific paths.

Documentation updates:

* Updated the permissions section in both `README.md` and `privacy/index.html` to explain that host access is granted by origin (`*.hilan.co.il` and `payroll.malam.com`), even though the content script only runs on specific paths.
* Updated the "last updated" date in the privacy policy to reflect the latest changes.